### PR TITLE
refactor: reduce copies, allocations, extra works

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,6 @@
 use clap::*;
 use std::ffi::OsString;
 
-use crate::commands::PnpmCommands;
-
 #[derive(Debug, Parser)]
 #[clap(author, version, about, rename_all = "kebab-case")]
 pub struct Cli {
@@ -20,32 +18,9 @@ pub enum Command {
     /// Runs a defined package script.
     #[clap(alias = "run-script")]
     Run(RunArgs),
-    #[clap(flatten)]
-    PnpmCommands(PnpmCommands),
     /// Execute a shell command in scope of a project.
     #[clap(external_subcommand)]
     Other(Vec<String>),
-}
-
-#[derive(Debug, Args)]
-#[clap(rename_all = "kebab-case")]
-pub struct PassedThroughArgs {
-    pub args: Vec<OsString>,
-}
-
-// Generate passed thro args from `env::args_os()`. `PnpmCommand` can be formatted to string
-// to get the command name, so all we need is the remaining args. This is better than maintaining
-// a `PassedThroughArgs` struct for all variants of `PnpmCommand` and also wouldnt bloat the
-// size of the enum
-impl std::default::Default for PassedThroughArgs {
-    fn default() -> Self {
-        let mut os_args = std::env::args_os();
-        os_args.next(); // skip the bin name
-        os_args.next(); // skip the command name
-        Self {
-            args: os_args.collect(),
-        }
-    }
 }
 
 /// Runs a defined package script.

--- a/src/passed_through.rs
+++ b/src/passed_through.rs
@@ -1,10 +1,9 @@
-use clap::Subcommand;
-use strum::{Display as StrumDisplay, EnumString};
+use strum::EnumString;
 
 /// An enum of commands that need to be passed to pnpm
-#[derive(Debug, PartialEq, EnumString, StrumDisplay, Subcommand, Clone)]
+#[derive(Debug, Clone, EnumString)]
 #[strum(use_phf, serialize_all = "kebab-case")]
-pub enum PnpmCommands {
+pub enum PassedThroughCommand {
     // commands that pnpm passes to npm
     Access,
     Adduser,


### PR DESCRIPTION
* rename `PnpmCommands` to `PassedThroughCommand`
* stop deriving `strum::Display`
* remove `handle_passed_through` and `PassedThroughArgs` entirely
* merge `Cli::PnpmCommands` into `Cli::Other`