### PR TITLE
feat: improve the code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "format-buf"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7aea5a5909a74969507051a3b17adc84737e31a5f910559892aedce026f4d53"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +443,7 @@ dependencies = [
  "clap",
  "derive_more",
  "dunce",
+ "format-buf",
  "indexmap",
  "itertools",
  "lets_find_up",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.10.5"
 dunce = "1.0.4"
 phf = { version = "0.11.2", features = ["macros" ]}
 os_display = { version = "0.1.3", features = ["unix", "windows"] }
+format-buf = "1.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,8 @@ fn run() -> Result<(), MainError> {
         let mut s = String::new();
         s += name;
         for arg in args {
-            format_buf!(s, " {}", Quoted::unix(arg));
+            let quoted = Quoted::unix(arg); // because pn uses `sh -c` even on Windows
+            format_buf!(s, " {quoted}");
         }
         s
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use error::{MainError, PnError};
 use format_buf::format as format_buf;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use os_display::Quotable;
+use os_display::Quoted;
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -79,7 +79,7 @@ fn run() -> Result<(), MainError> {
         let mut s = String::new();
         s += name;
         for arg in args {
-            format_buf!(s, " {}", arg.quote());
+            format_buf!(s, " {}", Quoted::unix(arg));
         }
         s
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use cli::Cli;
 use error::{MainError, PnError};
+use format_buf::format as format_buf;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use os_display::Quotable;
@@ -78,7 +79,7 @@ fn run() -> Result<(), MainError> {
         let mut s = String::new();
         s += name;
         for arg in args {
-            s += &format!(" {}", arg.quote());
+            format_buf!(s, " {}", arg.quote());
         }
         s
     };

--- a/tests/fixtures/append-script-args/list-args.sh
+++ b/tests/fixtures/append-script-args/list-args.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -o errexit -o nounset
+for arg in "$@"; do
+  echo "$arg"
+done

--- a/tests/fixtures/append-script-args/package.json
+++ b/tests/fixtures/append-script-args/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "list-args": "sh list-args.sh"
+  }
+}

--- a/tests/fixtures/append-script-args/stdout.txt
+++ b/tests/fixtures/append-script-args/stdout.txt
@@ -1,0 +1,5 @@
+foo
+bar
+hello world
+! !@
+abc def ghi

--- a/tests/test_main.rs
+++ b/tests/test_main.rs
@@ -61,6 +61,30 @@ fn run_script() {
 }
 
 #[test]
+fn append_script_args() {
+    let temp_dir = tempdir().unwrap();
+    let tree = MergeableFileSystemTree::<&str, &str>::from(dir! {
+        "package.json" => file!(include_str!("fixtures/append-script-args/package.json")),
+        "list-args.sh" => file!(include_str!("fixtures/append-script-args/list-args.sh")),
+    });
+    tree.build(&temp_dir).unwrap();
+
+    Command::cargo_bin("pn")
+        .unwrap()
+        .current_dir(&temp_dir)
+        .arg("run")
+        .arg("list-args")
+        .arg("foo")
+        .arg("bar")
+        .arg("hello world")
+        .arg("! !@")
+        .arg("abc def ghi")
+        .assert()
+        .success()
+        .stdout(include_str!("fixtures/append-script-args/stdout.txt"));
+}
+
+#[test]
 fn run_from_workspace_root() {
     let temp_dir = tempdir().unwrap();
     let tree = MergeableFileSystemTree::<&str, &str>::from(dir! {


### PR DESCRIPTION
* Use `format_buf` to avoid allocation and unwrap.
  * `std::format!` allocates a new string, should not be used.
  * `std::write!` returns a result, which requires `unwrap`.
* Force Unix style quoting on Windows.
  * Because `pn` currently uses `sh -c` regardless of Operating System.
* Add a test.